### PR TITLE
feat: cancel already running deploy job to only allow 1 running job

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,9 @@ on:
 jobs:
   dev-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: dev0-deploy-group
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v3
     - uses: webfactory/ssh-agent@v0.8.0


### PR DESCRIPTION
this is a small pr, which goal is to allow running only 1 deploy job at a time. To make this, we will cancel other possibly running job inside 'dev0-deploy' jobs group