### PR TITLE
refactor github actions to depend deploy job on a success run of test build

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,12 @@ name: "deploy branch to dev instance"
 on:
   workflow_dispatch
 jobs:
+  test_build:
+    uses: ./.github/workflows/test.yml
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
   dev-deploy:
+    needs: test_build
     runs-on: ubuntu-latest
     concurrency:
       group: dev0-deploy-group

--- a/.github/workflows/op-energy.yml
+++ b/.github/workflows/op-energy.yml
@@ -3,23 +3,7 @@ on:
   pull_request:
     types: [opened, ready_for_review, synchronize, workflow_dispatch]
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: webfactory/ssh-agent@v0.8.0
-      with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-    - uses: cachix/install-nix-action@v25
-      with:
-        nix_path: nixpkgs=channel:nixos-23.11
-        extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
-    - run: git clone ssh://git@github.com/op-energy-foundation/op-energy-dev-instance.git ../op-energy-dev-instance --recursive
-    # current repo's use case is to be submodule in 80% of cases, so we need to copy content of op-energy repo into a proper submodule location
-    - run: rm -rf ../op-energy-dev-instance/overlays/op-energy/oe-blockspan-service/* && cp -r $(pwd)/* ../op-energy-dev-instance/overlays/op-energy/oe-blockspan-service/
-    - run: echo \"ci-host\" > ../op-energy-dev-instance/local_hostname.nix
-    # ci-tests.nix should be on the same level as op-energy-development
-    - run: cp ci-tests.nix ../
-    # now actually run the builds and tests with passing git commit hash as an argument
-    - run: cd ../ && nix-build ci-tests.nix --argstr GIT_COMMIT_HASH $( echo ${{github.sha}} | cut -c 1-8 )
-
+  test_build:
+    uses: ./.github/workflows/test.yml
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: "test build"
+on:
+  workflow_call:
+    secrets:
+      SSH_PRIVATE_KEY:
+        required: true
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: webfactory/ssh-agent@v0.8.0
+      with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-23.11
+        extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
+    - run: git clone ssh://git@github.com/op-energy-foundation/op-energy-dev-instance.git ../op-energy-dev-instance --recursive
+    # current repo's use case is to be submodule in 80% of cases, so we need to copy content of op-energy repo into a proper submodule location
+    - run: rm -rf ../op-energy-dev-instance/overlays/op-energy/oe-blockspan-service/* && cp -r $(pwd)/* ../op-energy-dev-instance/overlays/op-energy/oe-blockspan-service/
+    - run: echo \"ci-host\" > ../op-energy-dev-instance/local_hostname.nix
+    # ci-tests.nix should be on the same level as op-energy-development
+    - run: cp ci-tests.nix ../
+    # now actually run the builds and tests with passing git commit hash as an argument
+    - run: cd ../ && nix-build ci-tests.nix --argstr GIT_COMMIT_HASH $( echo ${{github.sha}} | cut -c 1-8 )
+


### PR DESCRIPTION
This PR refactors github actions workflow with:

1. test build is now implemented as a reusable workflow, that can be used from other workflows;
2. deploy to development instance action is now requires successful test build (as a reusable workflow) before actually deploy into 
development instance. Until this PR, it was possible to try to deploy failed state

What will be changed for user: the only difference is that when user starts deploy job, he will see 2 steps of actions: 1. test build; 2. deploy action. Previously, user saw only step 2