### PR TITLE
provide unconfirmed tip block height in websocket messages

### DIFF
--- a/op-energy-api/op-energy-api.cabal
+++ b/op-energy-api/op-energy-api.cabal
@@ -74,5 +74,6 @@ library
                     , http-media
                     , http-client, http-client-tls, servant-client
                     , mtl
+                    , transformers
 
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans


### PR DESCRIPTION
This PR adds 'oe-latest-unconfirmed-block-height' field for websocket messages. This makes possible for websocket clients to understand what unconfirmed tip block height is without guessing if blockspan service's confirmation threshold match client's threshold