### PR TITLE
provide swagger spec ui component for internal blocktime API

### DIFF
--- a/frontend/src/app/oe/components/oe-docs/oe-docs.component.html
+++ b/frontend/src/app/oe/components/oe-docs/oe-docs.component.html
@@ -1,3 +1,4 @@
 <div id="swagger-blockspan-service" class="swagger"></div>
 <div id="swagger-account-service" class="swagger"></div>
 <div id="swagger-blocktime-service" class="swagger"></div>
+<div id="swagger-internal-blocktime-service" class="swagger"></div>

--- a/frontend/src/app/oe/components/oe-docs/oe-docs.component.ts
+++ b/frontend/src/app/oe/components/oe-docs/oe-docs.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit, OnDestroy } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { OeEnergyApiService } from './../../services/oe-energy.service';
 import { OeAccountApiService } from './../../services/oe-energy.service';
-import { OeBlocktimeApiService } from './../../services/oe-energy.service';
+import { OeBlocktimeApiService, OeInternalBlocktimeApiService } from './../../services/oe-energy.service';
 import { Subscription } from 'rxjs';
 import { DOCUMENT } from '@angular/common';
 import { SwaggerUIBundle, SwaggerUIStandalonePreset } from 'swagger-ui-dist';
@@ -18,15 +18,18 @@ export class OeDocsComponent implements OnDestroy, OnInit, AfterViewInit {
   swaggerDomBlockspanService: HTMLElement;
   swaggerDomAccountService: HTMLElement;
   swaggerDomBlocktimeService: HTMLElement;
+  swaggerDomInternalBlocktimeService: HTMLElement;
   blockspanServiceSpecSubscription: Subscription;
   accountServiceSpecSubscription: Subscription;
   blocktimeServiceSpecSubscription: Subscription;
+  internalBlocktimeServiceSpecSubscription: Subscription;
 
   constructor(
     @Inject(DOCUMENT) public document: Document,
     private oeEnergyApiService: OeEnergyApiService,
     private oeAccountApiService: OeAccountApiService,
-    private oeBlocktimeApiService: OeBlocktimeApiService
+    private oeBlocktimeApiService: OeBlocktimeApiService,
+    private oeInternalBlocktimeApiService: OeInternalBlocktimeApiService,
   ) {}
 
   ngOnInit() {}
@@ -41,6 +44,7 @@ export class OeDocsComponent implements OnDestroy, OnInit, AfterViewInit {
     this.swaggerDomBlockspanService = this.document.getElementById('swagger-blockspan-service');
     this.swaggerDomAccountService = this.document.getElementById('swagger-account-service');
     this.swaggerDomBlocktimeService = this.document.getElementById('swagger-blocktime-service');
+    this.swaggerDomInternalBlocktimeService = this.document.getElementById('swagger-internal-blocktime-service');
     this.blockspanServiceSpecSubscription = this.oeEnergyApiService
       .$getSwaggerFile()
       .subscribe((data) => {
@@ -64,6 +68,17 @@ export class OeDocsComponent implements OnDestroy, OnInit, AfterViewInit {
         });
       });
     this.blocktimeServiceSpecSubscription = this.oeBlocktimeApiService
+      .$getSwaggerFile()
+      .subscribe((data) => {
+        SwaggerUIBundle({
+          spec: data,
+          domNode: this.swaggerDomBlocktimeService,
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: 'StandaloneLayout',
+        });
+      });
+    this.internalBlocktimeServiceSpecSubscription = this.oeInternalBlocktimeApiService
       .$getSwaggerFile()
       .subscribe((data) => {
         SwaggerUIBundle({

--- a/frontend/src/app/oe/services/oe-energy.service.ts
+++ b/frontend/src/app/oe/services/oe-energy.service.ts
@@ -502,3 +502,27 @@ export class OeBlocktimeApiService {
     });
   }
 }
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OeInternalBlocktimeApiService {
+  private apiBaseUrl: string; // base URL is protocol, hostname, and port
+  private apiBasePath: string; // network path is /testnet, etc. or '' for mainnet
+  constructor(
+    private httpClient: HttpClient,
+    private oeEnergyStateService: OeStateService
+  ) {
+    this.apiBaseUrl =
+      document.location.protocol + '//' + document.location.host; // use relative URL by default
+    this.apiBasePath = '';
+  }
+
+  // returns swagger API json
+  $getSwaggerFile(): Observable<SwaggerJson> {
+    return this.httpClient.get<SwaggerJson>(
+      this.apiBaseUrl + this.apiBasePath + '/api/v1/blocktime/internal/api/v1/blocktime/swagger.json',
+      {}
+    );
+  }
+}


### PR DESCRIPTION
This PR adds swagger spec UI for internal blocktime service API, that is intended to be used to provide unauthorized  API for block strike creations (ie, for example for scheduiler scripts)