### PR TITLE
test: add initial tests for serialization

### DIFF
--- a/op-energy-api/op-energy-api.cabal
+++ b/op-energy-api/op-energy-api.cabal
@@ -24,6 +24,16 @@ version:            0.1.0.0
 -- copyright:
 -- category:
 
+common warnings
+    ghc-options: -Wall -Werror -Wno-orphans -fno-warn-name-shadowing
+    default-language: Haskell2010
+    default-extensions: OverloadedStrings
+                      , ScopedTypeVariables
+                      , FlexibleContexts
+                      , TypeOperators
+                      , BangPatterns
+                      , DeriveFunctor
+
 executable op-energy-api
     main-is:          Main.hs
 
@@ -78,5 +88,52 @@ library
                     , mtl
                     , transformers
                     , data-default
+                    , QuickCheck
 
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
+
+test-suite op-energy-api-test
+    -- Import common warning flags.
+    import:           warnings
+
+    -- Base language which the package is written in.
+    default-language: Haskell2010
+
+    -- Modules included in this executable, other than Main.
+    other-modules:
+                      OpEnergy.API.V1.BlockSpec
+                    , OpEnergy.API.V1.HashSpec
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+
+    -- The interface type and version of the test suite.
+    type:             exitcode-stdio-1.0
+
+    -- Directories containing source files.
+    hs-source-dirs:   test
+
+    -- The entrypoint to the test suite.
+    main-is:          Spec.hs
+
+    -- Test dependencies.
+    build-depends: base >=4.15.1.0
+        , op-energy-api
+        , hspec
+        , QuickCheck
+        , text
+        , mtl
+        , stm
+        , vector
+        , time
+        , containers
+        , transformers
+        , random
+        , conduit
+        , aeson
+        , persistent
+        , servant
+
+    ghc-options: -rtsopts -threaded
+
+

--- a/op-energy-api/op-energy-api.nix
+++ b/op-energy-api/op-energy-api.nix
@@ -55,6 +55,6 @@ mkDerivation {
   enableSeparateBinOutput = false;
   testHaskellDepends = [ base hspec text ];
   doBenchmark = false;
-  doCheck = false;
+  doCheck = true;
   license = lib.licenses.bsd3;
 }

--- a/op-energy-api/src/Data/OpEnergy/API/V1/Block.hs
+++ b/op-energy-api/src/Data/OpEnergy/API/V1/Block.hs
@@ -108,27 +108,34 @@ instance ToSchema BlockHeader where
       def1 :: Default a => Proxy a-> a
       def1 _ = def
 instance Arbitrary BlockHeader where
-  arbitrary = (BlockHeader
-    <$> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    <*> arbitrary
-    ) `QC.suchThat` (\v -> case everifyBlockHeader v of
-                             Right _ -> True
-                             _ -> False
-                    )
+  arbitrary = do
+    height <- arbitrary
+    let
+        mediantime = genesisMediantime + fromIntegral height * 600
+    mediantimeInt <- (QC.choose (mediantime - 400, mediantime + 400)::(QC.Gen Word32))
+    (BlockHeader
+      <$> arbitrary
+      <*> arbitrary
+      <*> return height
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> return mediantimeInt
+      <*> arbitrary
+      <*> arbitrary
+      ) `QC.suchThat` (\v -> case everifyBlockHeader v of
+                               Right _ -> True
+                               _ -> False
+                      )
+    where
+      genesisMediantime = 1732551056
 
 type BlockHash = Hash
 

--- a/op-energy-api/src/Data/OpEnergy/API/V1/Hash.hs
+++ b/op-energy-api/src/Data/OpEnergy/API/V1/Hash.hs
@@ -27,6 +27,11 @@ import           Data.Word (Word8)
 import qualified Data.Text.Encoding as TE
 import           Control.Monad (replicateM)
 import           System.Random
+import qualified Data.List as List
+import qualified Data.Char as Char
+
+import           Test.QuickCheck(Arbitrary(..))
+import qualified Test.QuickCheck as QC
 
 import           Database.Persist
 import           Database.Persist.Sql
@@ -58,6 +63,15 @@ instance PersistField Hash where
   fromPersistValue _ = Left $ "InputVerification.hs fromPersistValue Hash , expected Text"
 instance PersistFieldSql Hash where
   sqlType _ = SqlString
+
+instance Arbitrary Hash where
+  arbitrary = do
+    bs <- (BS.toShort . BS.pack . List.map (fromIntegral . Char.ord) )
+      <$> (replicateM 64 $! QC.oneof $! digits ++ alphas)
+    return $! Hash bs
+    where
+    digits = [QC.choose ('0', '9')]
+    alphas = [QC.choose ('a', 'f')]
 
 
 defaultHash :: Hash

--- a/op-energy-api/test/OpEnergy/API/V1/BlockSpec.hs
+++ b/op-energy-api/test/OpEnergy/API/V1/BlockSpec.hs
@@ -1,0 +1,29 @@
+module OpEnergy.API.V1.BlockSpec
+  ( spec
+  ) where
+
+import qualified Data.Aeson as Aeson
+import qualified Database.Persist as Persist
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Data.OpEnergy.API.V1.Block
+
+spec :: Spec
+spec = do
+  blockHeaderSpecs
+  blockSpanSpecs
+
+blockHeaderSpecs :: Spec
+blockHeaderSpecs = do
+  describe "BlockHeader serialization" $ do
+    it "from/to JSON should be the same" $
+      property $ \(x::BlockHeader) -> Aeson.eitherDecode (Aeson.encode x) == Right x
+    it "from/to Persist should be the same" $
+      property $ \(x::BlockHeader) -> Persist.fromPersistValue (Persist.toPersistValue x) == Right x
+
+blockSpanSpecs :: Spec
+blockSpanSpecs = do
+  describe "BlockSpan serialization" $ do
+    it "from/to JSON should be the same" $
+      property $ \(x::BlockSpan) -> Aeson.eitherDecode (Aeson.encode x) == Right x

--- a/op-energy-api/test/OpEnergy/API/V1/HashSpec.hs
+++ b/op-energy-api/test/OpEnergy/API/V1/HashSpec.hs
@@ -1,0 +1,23 @@
+module OpEnergy.API.V1.HashSpec
+  ( spec
+  ) where
+
+import qualified Data.Aeson as Aeson
+import qualified Database.Persist as Persist
+import qualified Servant.API as API
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Data.OpEnergy.API.V1.Hash
+
+spec :: Spec
+spec = do
+  describe "Hash serialization" $ do
+    it "from/to JSON should be the same" $
+      property $ \(x::Hash) -> Aeson.eitherDecode (Aeson.encode x) == Right x
+    it "from/to Persist should be the same" $
+      property $ \(x::Hash) -> Persist.fromPersistValue (Persist.toPersistValue x) == Right x
+    it "from/to HTTP should be the same" $
+      property $ \(x::Hash) -> API.parseUrlPiece (API.toUrlPiece x) == Right x
+    it "from/to HTTP should be the same" $
+      property $ \(x::Hash) -> API.parseQueryParam (API.toQueryParam x) == Right x

--- a/op-energy-api/test/Spec.hs
+++ b/op-energy-api/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+


### PR DESCRIPTION
This PR introduces some basic tests for BlockHeader, BlockSpan, Hash datatypes.

Other than that, it provides Arbitrary instances, which are essential to tests in other services (account, blocktime)