### PR TITLE
81 Removed v2 from urls and preview text

### DIFF
--- a/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.scss
+++ b/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.scss
@@ -275,7 +275,7 @@
 
           // Active button styles
           &.active {
-            border: 3px solid #ffc107;
+            border: 0.25em solid #ffc107;
             color: #fff; // White text for active state
             box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); // Add slight shadow for emphasis
           }

--- a/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.scss
+++ b/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.scss
@@ -245,6 +245,7 @@
             color: black;
             font-size: 1.5rem;
             width: 14rem;
+            font-weight: bold
           }
 
           .oe-icon {
@@ -266,24 +267,17 @@
 
             // Optional hover effects for disabled stateoe-message-container
             &:hover {
-              background-color: #e0e0e0;
-              border-color: #d3d3d3;
-              color: #a0a0a0;
+              background-color: #f5f5f5;
+              color: #333;
+              transition: all 0.2s ease-in-out;
             }
           }
 
           // Active button styles
           &.active {
-            background-color: #ffc107;
-            border-color: #ffc107; // Gold border for active state
+            border: 3px solid #ffc107;
             color: #fff; // White text for active state
             box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); // Add slight shadow for emphasis
-
-            // Add hover effect for active button
-            &:hover {
-              background-color: darken(#ffc107, 5%); // Darken on hover
-              border-color: darken(#ffc107, 5%);
-            }
           }
         }
       }

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
@@ -134,7 +134,7 @@
     
               // Active button styles
               &.active {
-                border: 3px solid #ffc107;
+                border: 0.25em solid #ffc107;
                 box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); // Add slight shadow for emphasis
               }
             }

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
@@ -112,6 +112,7 @@
             .btn {
               color: black;
               font-size: 1.5rem;
+              font-weight: bold;
               width: 14rem;
               // Default button styles
               border-radius: 5px;
@@ -121,29 +122,20 @@
               &:disabled {
                 background-color: #e0e0e0; // Light gray background for disabled
                 border-color: #d3d3d3; // Gray border
-                color: #a0a0a0; // Light gray text
                 cursor: not-allowed; // Show "not-allowed" cursor on hover
     
                 // Optional hover effects for disabled stateoe-message-container
                 &:hover {
-                  background-color: #e0e0e0;
-                  border-color: #d3d3d3;
-                  color: #a0a0a0;
+                  background-color: #f5f5f5;
+                  color: #333;
+                  transition: all 0.2s ease-in-out;
                 }
               }
     
               // Active button styles
               &.active {
-                background-color: #ffc107;
-                border-color: #ffc107; // Gold border for active state
-                color: #fff; // White text for active state
+                border: 3px solid #ffc107;
                 box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); // Add slight shadow for emphasis
-    
-                // Add hover effect for active button
-                &:hover {
-                  background-color: darken(#ffc107, 5%); // Darken on hover
-                  border-color: darken(#ffc107, 5%);
-                }
               }
             }
           }

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.ts
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.ts
@@ -318,7 +318,7 @@ export class BlockrateStrikeSummaryV2Component implements OnInit {
     };
 
     // Navigate to the target route with the query parameters
-    this.router.navigate(['/hashstrikes/blockrate-strike-details-v2'], { queryParams });
+    this.router.navigate(['/hashstrikes/blockrate-strike-details'], { queryParams });
   }
 
   getStrikeRate(): string {

--- a/frontend/src/app/oe/components/blockrates-graph/block-rates-graph.component.ts
+++ b/frontend/src/app/oe/components/blockrates-graph/block-rates-graph.component.ts
@@ -469,7 +469,7 @@ export class BlockRatesGraphComponent implements OnInit {
     // Handle click event for line or bar series
     const { startBlockHeight, endBlockHeight } = this.chartData[dataIndex];
     window.open(
-      `${document.location.protocol}//${document.location.host}/hashstrikes/blockrate-summary-v2?startblock=${startBlockHeight}&endblock=${endBlockHeight}`,
+      `${document.location.protocol}//${document.location.host}/hashstrikes/blockrate-summary?startblock=${startBlockHeight}&endblock=${endBlockHeight}`,
       '_blank'
     );
   }

--- a/frontend/src/app/oe/components/my-guesses/my-guesses.component.ts
+++ b/frontend/src/app/oe/components/my-guesses/my-guesses.component.ts
@@ -75,6 +75,6 @@ export class MyGuessesComponent implements OnInit {
     }
 
     // Navigate to the target route with the query parameters
-    this.router.navigate(['/hashstrikes/blockrate-strike-summary-v2'], { queryParams });
+    this.router.navigate(['/hashstrikes/blockrate-strike-summary'], { queryParams });
   }
 }

--- a/frontend/src/app/oe/components/preview/preview.component.html
+++ b/frontend/src/app/oe/components/preview/preview.component.html
@@ -4,28 +4,28 @@
 <div class="preview-component text-center"  *ngIf="!isLoading">
   <div><a [routerLink]="blockspansLink()">Blockspans</a></div>
   <div>
-    <a [href]="blockspanDetails()">Blockspan Detail v2</a>
+    <a [href]="blockspanDetails()">Blockspan Detail</a>
   </div>
   <div>
-    <a [href]="blockspanSummaryLink('past')">Blockrate Summary(Past) v2</a>
+    <a [href]="blockspanSummaryLink('past')">Blockrate Summary(Past)</a>
   </div>
   <div>
-    <a [href]="blockspanSummaryLink()">Blockrate Summary(Future) v2</a>
+    <a [href]="blockspanSummaryLink()">Blockrate Summary(Future)</a>
   </div>
   <div>
-    <a [href]="blockrateStrikeDetailsV2('past')">Blockrate Strike Detail(Past) v2</a>
+    <a [href]="blockrateStrikeDetailsV2('past')">Blockrate Strike Detail(Past)</a>
   </div>
   <div>
-    <a [href]="blockrateStrikeDetailsV2()">Blockrate Strike Detail(Future) v2</a>
+    <a [href]="blockrateStrikeDetailsV2()">Blockrate Strike Detail(Future)</a>
   </div>
   <div>
-    <a [href]="blockrateStrikeDetailsV2('next-difficulty')">Blockrate Strike Detail(Next Difficulty Adjustment) v2</a>
+    <a [href]="blockrateStrikeDetailsV2('next-difficulty')">Blockrate Strike Detail(Next Difficulty Adjustment)</a>
   </div>
   <div>
-    <a [href]="blockrateStrikeSummaryV2('past')">Blockrate Strike Summary(Past) v2</a>
+    <a [href]="blockrateStrikeSummaryV2('past')">Blockrate Strike Summary(Past)</a>
   </div>
   <div>
-    <a [href]="blockrateStrikeSummaryV2()">Blockrate Strike Summary(Future) v2</a>
+    <a [href]="blockrateStrikeSummaryV2()">Blockrate Strike Summary(Future)</a>
   </div>
   <div><a [routerLink]="myGuesses()">My Guesses</a></div>
   <h2 class="pt-5 pb-3">LIST OF BLOCKRATE STRIKES</h2>

--- a/frontend/src/app/oe/components/preview/preview.component.ts
+++ b/frontend/src/app/oe/components/preview/preview.component.ts
@@ -158,31 +158,31 @@ export class PreviewComponent implements OnInit {
     type: 'past' | 'future' | 'next-difficulty' = 'future'
   ): string {
     if (type === 'past') {
-      return `/hashstrikes/blockrate-strike-details-v2?strikeHeight=844447&strikeTime=1716298890&startblock=844433`;
+      return `/hashstrikes/blockrate-strike-details?strikeHeight=844447&strikeTime=1716298890&startblock=844433`;
     }
 
     if (type === 'next-difficulty') {
       const { startBlock, endBlock, strikeTime } = getNextDifficultyAdjustment(
         this.epochBlock
       );
-      return `/hashstrikes/blockrate-strike-details-v2?strikeHeight=${endBlock}&strikeTime=${strikeTime}&startblock=${startBlock}`;
+      return `/hashstrikes/blockrate-strike-details?strikeHeight=${endBlock}&strikeTime=${strikeTime}&startblock=${startBlock}`;
     }
 
-    return `/hashstrikes/blockrate-strike-details-v2?strikeHeight=${this.latestStrike?.strike?.block}&strikeTime=${this.latestStrike?.strike?.strikeMediantime}&startblock=${this.latestBlock?.height}`;
+    return `/hashstrikes/blockrate-strike-details?strikeHeight=${this.latestStrike?.strike?.block}&strikeTime=${this.latestStrike?.strike?.strikeMediantime}&startblock=${this.latestBlock?.height}`;
   }
 
   blockrateStrikeSummaryV2(type: 'past' | 'future' = 'future'): string {
     if (type === 'past') {
-      return `/hashstrikes/blockrate-strike-summary-v2?strikeHeight=844447&strikeTime=1716298890&startblock=844433`;
+      return `/hashstrikes/blockrate-strike-summary?strikeHeight=844447&strikeTime=1716298890&startblock=844433`;
     }
-    return `/hashstrikes/blockrate-strike-summary-v2?strikeHeight=${this.latestStrike?.strike?.block}&strikeTime=${this.latestStrike?.strike?.strikeMediantime}&startblock=${this.latestBlock?.height}`;
+    return `/hashstrikes/blockrate-strike-summary?strikeHeight=${this.latestStrike?.strike?.block}&strikeTime=${this.latestStrike?.strike?.strikeMediantime}&startblock=${this.latestBlock?.height}`;
   }
 
   blockspanSummaryLink(type: 'past' | 'future' = 'future'): string {
     if (type === 'past') {
-      return `/hashstrikes/blockrate-summary-v2?startblock=849237&endblock=849251`;
+      return `/hashstrikes/blockrate-summary?startblock=849237&endblock=849251`;
     }
 
-    return `/hashstrikes/blockrate-summary-v2?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}`;
+    return `/hashstrikes/blockrate-summary?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}`;
   }
 }

--- a/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
+++ b/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
@@ -161,13 +161,13 @@ export class StrikesRangeComponent implements OnInit {
     };
 
     if (this.guessableScreen) {
-      this.router.navigate(['/hashstrikes/blockrate-strike-summary-v2'], {
+      this.router.navigate(['/hashstrikes/blockrate-strike-summary'], {
         queryParams,
       });
       return;
     }
 
     // Use the Router service to navigate with query parameters
-    this.router.navigate(['/hashstrikes/blockrate-strike-details-v2'], { queryParams });
+    this.router.navigate(['/hashstrikes/blockrate-strike-details'], { queryParams });
   }
 }

--- a/frontend/src/app/oe/oe.routing.modules.ts
+++ b/frontend/src/app/oe/oe.routing.modules.ts
@@ -68,15 +68,15 @@ const routes: Routes = [
             component: MyGuessesComponent
           },
           {
-            path: 'blockrate-strike-details-v2',
+            path: 'blockrate-strike-details',
             component: BlockRateStrikeDetailsV2Component
           },
           {
-            path: 'blockrate-strike-summary-v2',
+            path: 'blockrate-strike-summary',
             component: BlockrateStrikeSummaryV2Component
           },
           {
-            path: 'blockrate-summary-v2',
+            path: 'blockrate-summary',
             component: BlockrateSummaryV2Component
           },
           {


### PR DESCRIPTION
### Description  
1. This PR removes all references to "v2" from the preview page links and URLs to ensure consistency and correctness.
2. Updates the visual language for "which guess was selected" by implementing an orange border instead of coloring the entire rectangle. This makes the selection clearer and avoids potential confusion with speed indicators.


### Changes Made  
- Removed "v2" from all link texts.  
- Updated URLs that contained "v2" to exclude it.  
- Verified that all links remain functional after the update.  
- Changed the selection indicator to use an orange border instead of a filled rectangle.  
