### PR TITLE
Add New Summary Widget Screen, Format Support, and URL Schema Update

### DIFF
--- a/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.html
+++ b/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.html
@@ -17,30 +17,40 @@
                     <div class="footer oe-link" (click)="goToStrikeDetails($event)">blockrate</div>
                     <div class="logo oe-link" (click)="goToStrikeDetails($event)"><span class="logo-container">{{ logos.BLOCKS }}</span></div>
                 </div>
-                <div class="guessing-container">
+                <div class="guessing-container" *ngIf="format === 'widget'">
                     <div class="oe-message-container">
                     </div>
                 </div>
             </div>
         </div>
         <div class="block-container">
-            <div *ngFor="let strike of strikesData" class="blockspan guessing-block">
-                <div class="guessing-container">
-                    <app-blockrate-strike-summary-v2
-                        [fromBlock]="fromBlock"
-                        [toBlock]="toBlock"
-                        [strike]="strike.strike">
-                    </app-blockrate-strike-summary-v2>
-                    <!-- Planning to reuse below commented code in another component -->
-                    <!-- <app-guessing-game
-                        [fromBlock]="fromBlock"
-                        [toBlock]="toBlock"
-                        [strike]="strike.strike">
-                    </app-guessing-game> -->
-                    <!-- <div class="logo">
-                        <span class="logo-container">{{ logos.CONTRACT }}</span>
-                        <span class="logo-container">{{ logos.BLOCKS }}</span>
-                    </div> -->
+            <ng-container *ngIf="format === 'widget'" >
+                <div *ngFor="let strike of strikesData" class="blockspan guessing-block">
+                    <div class="guessing-container">
+                        <app-blockrate-strike-summary-v2
+                            [fromBlock]="fromBlock"
+                            [toBlock]="toBlock"
+                            [strike]="strike.strike">
+                        </app-blockrate-strike-summary-v2>
+                        <!-- Planning to reuse below commented code in another component -->
+                        <!-- <app-guessing-game
+                            [fromBlock]="fromBlock"
+                            [toBlock]="toBlock"
+                            [strike]="strike.strike">
+                        </app-guessing-game> -->
+                        <!-- <div class="logo">
+                            <span class="logo-container">{{ logos.CONTRACT }}</span>
+                            <span class="logo-container">{{ logos.BLOCKS }}</span>
+                        </div> -->
+                    </div>
+                </div>
+            </ng-container>
+            <div class="strike-list" *ngIf="!format || format === 'line'">
+                <div class="strike-table m-5 text-center">
+                    <div class="content">
+                        <app-data-table [headers]="headers" [data]="tableData" (rowClicked)="onChildRowClick($event)">
+                        </app-data-table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.scss
+++ b/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.scss
@@ -20,6 +20,58 @@
     
         .block-container {
           width: 100%;
+          .strike-list {
+            .strike-table {
+                .content {
+                  word-wrap: break-word;
+                  background-color: #24273e;
+                  background-clip: border-box;
+                  border: 1px solid rgba(0, 0, 0, 0.125);
+                  box-shadow: 0.125rem 0.125rem 0.25rem #00000013;
+                  margin: 15px 0;
+          
+                  .table {
+                    tr {
+                      white-space: initial;
+                    }
+          
+                    td {
+                      word-break: break-all;
+                      max-width: 300px;
+                    }
+                  }
+          
+                  .outcome {
+                    background-color: blue;
+                    padding: 3px 10px;
+          
+                    &.hot {
+                      background-color: red;
+                    }
+                  }
+                }
+              }
+          
+              @media (max-width: 768px) {
+                flex-direction: column;
+                align-items: center;
+                gap: 50px;
+          
+                ::ng-deep .blockspan .tetris-blockspan {
+                  height: 330px;
+                }
+          
+                .blockspan-table {
+                  width: 100%;
+                  padding: 20px;
+          
+                  .content {
+                    width: 100%;
+                    overflow: auto;
+                  }
+                }
+              }
+          }        
         }
   
         .blockspan {

--- a/frontend/src/app/oe/components/blockrates-graph/block-rates-graph.component.ts
+++ b/frontend/src/app/oe/components/blockrates-graph/block-rates-graph.component.ts
@@ -196,7 +196,7 @@ export class BlockRatesGraphComponent implements OnInit {
     let title: object;
     const chartData = data.map((item) => ({
       nbdr: item.nbdr,
-      hashrate: parseInt('0x' + item.hashrate) / 100,
+      hashrate: BigInt('0x' + item.hashrate).toString(),
       originalhashrate: item.hashrate,
       startBlockHeight: item.startBlock.height,
       endBlockHeight: item.endBlock.height,
@@ -214,10 +214,10 @@ export class BlockRatesGraphComponent implements OnInit {
     const maxValue = Math.max(...chartData.map((item) => item.nbdr));
 
     const minHashrateValue = Math.floor(
-      Math.min(...chartData.map((item) => item.hashrate)) * 0.9
+      Math.min(...chartData.map((item) => Number(BigInt(item.hashrate)))) * 0.9
     );
     const maxHashrateValue = Math.ceil(
-      Math.max(...chartData.map((item) => item.hashrate)) * 1.1
+      Math.max(...chartData.map((item) => Number(BigInt(item.hashrate)))) * 1.1
     );
 
     const yAxisMin = Math.floor(minValue * 0.9);

--- a/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.html
+++ b/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.html
@@ -30,8 +30,7 @@
                     footerText="blocks" [displayLogo]="false" [footerLogo]="logos.BLOCKS"></app-box>
                 <app-box class="hashes" [fromLabel]="fromBlock.hash" [toLabel]="toBlock.hash" footerText="block hashes"
                     background="#ffff00" [displayBlock]="false" [displayLogo]="false" [isToolTipEnabled]="true"></app-box>
-                <app-box class="hashes difficulty" [fromLabel]="getDifficulty(fromBlock.hash)" [toLabel]="getDifficulty(toBlock.hash)" footerText="block difficulty embodied in zeros
-                    of block hash: 16 ^ (numbers of zeros at left -8)" background="#cf2a27" [displayBlock]="false" [displayLogo]="false" [isToolTipEnabled]="true"></app-box>
+                <app-box class="hashes difficulty" [fromLabel]="getDifficulty(fromBlock.hash)" [toLabel]="getDifficulty(toBlock.hash)" footerText="napkin math block difficulty: 16 ^ (numbers of red zeros + 1)" background="#cf2a27" [displayBlock]="false" [displayLogo]="false" [isToolTipEnabled]="true"></app-box>
                 <app-box class="hashes difficulty origina-difficulty" [fromLabel]="formatNumberToString(fromBlock?.difficulty)" [toLabel]="formatNumberToString(toBlock.difficulty)" footerText="actual difficulty" background="#cf2a27" [displayBlock]="false" [displayLogo]="false" [isToolTipEnabled]="true"></app-box>
             </div>
             <div class="blockspan-bottom">

--- a/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.scss
+++ b/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.scss
@@ -132,10 +132,13 @@
               font-size: 0.6rem;
 
               .leading-zeros {
-                color: red;
                 white-space: pre;
                 overflow: hidden;
                 width: 9.5rem;
+
+                .red {
+                  color: red;
+                }
               }
 
               .remaining-text {

--- a/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
+++ b/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
@@ -120,7 +120,15 @@ export class BlockspanBHSComponent implements OnInit {
 
       const groupedZeros = leadingZeros
         .match(/.{1,4}/g) // Break into chunks of 4
-        ?.map((group) => (group.length < 4 ? group.padEnd(4, '\u00A0') : group)) // Pad final group with spaces
+        ?.map((group, index, arr) => {
+          const paddedGroup =
+            group.length < 4 ? group.padEnd(4, '\u00A0') : group;
+          const groupIndexFromRight = arr.length - 1 - index;
+          if (groupIndexFromRight <= 2) {
+            return `<span class="red">${paddedGroup}</span>`;
+          }
+          return paddedGroup;
+        })
         .join('\u00A0'); // Join groups with spaces between them
 
       // Return HTML with leading zeros wrapped in a span
@@ -310,8 +318,8 @@ export class BlockspanBHSComponent implements OnInit {
     // Retrieve values from getSpan for 'hashes' and 'satoshis'
     const regex = /(0+)(.*)$/;
     const match = type.match(regex);
-    const diffcult = match ? match[1].length : 8;
-    return `>= ${this.formatNumberToString(Math.pow(16, diffcult - 8))}`;
+    const diffcult = Math.max(match ? match[1].length - 8 : 0, 8);
+    return `>= ${this.formatNumberToString(Math.pow(16, diffcult + 1))}`;
   }
 
   formatNumberToString(input: string | number): string {

--- a/frontend/src/app/oe/components/common/base-block/BaseBlockComponent.ts
+++ b/frontend/src/app/oe/components/common/base-block/BaseBlockComponent.ts
@@ -27,6 +27,7 @@ import {
   calculateTimeDifference,
   convertToUTC
 } from '../../../utils/helper';
+import { FormatType } from '../../../types/constant';
 
 export abstract class BaseBlockComponent {
   fromBlock: Block;
@@ -37,6 +38,7 @@ export abstract class BaseBlockComponent {
   calculateTimeDifference = calculateTimeDifference;
   convertToUTC = convertToUTC;
   strike: BlockTimeStrike = {} as BlockTimeStrike;
+  format: FormatType = FormatType.LINE;
 
   constructor(
     protected router: Router,
@@ -92,6 +94,7 @@ export abstract class BaseBlockComponent {
       endblock: this.latestBlock?.height || undefined,
       strikeHeight: 1200000,
       strikeTime: undefined,
+      format: FormatType.LINE
     };
     const params: { [key: string]: any } = { ...defaultParams };
     route.queryParamMap.pipe(take(1)).subscribe((paramMap: ParamMap) => {

--- a/frontend/src/app/oe/components/preview/preview.component.html
+++ b/frontend/src/app/oe/components/preview/preview.component.html
@@ -59,8 +59,13 @@
   <div>
     <a [href]="guessableStrikeListNewestToOldestLink()">All Guessable(newest to oldest)</a>
   </div>
+
   <div>
-    <a [href]="strikeListSortByGuess()">All Range(With guess highest to lowest)</a>
+    <a [href]="endBlockNWithStrikeSummary()">Ending in Block N(as summary widgets)</a>
+  </div>
+
+  <div>
+    <a [href]="strikeListSortByGuess()">Range(With guess highest to lowest)</a>
   </div>
   <div>
     <a [href]="strikesRangeWithStartblockEndblock()">Range(With startblock and endblock)</a>

--- a/frontend/src/app/oe/components/preview/preview.component.ts
+++ b/frontend/src/app/oe/components/preview/preview.component.ts
@@ -91,7 +91,7 @@ export class PreviewComponent implements OnInit {
   }
 
   pastStrikeListOldestToNewestLink(type?: string): string {
-    const url = '/hashstrikes/blockrate-strikes-range?sort=ascend&page=1';
+    const url = '/hashstrikes/blockrate-strikes-by-blockrate-summary?sort=ascend&page=1';
 
     if (type) {
       return `${url}&result=${type}`;
@@ -100,7 +100,7 @@ export class PreviewComponent implements OnInit {
   }
 
   pastStrikeListNewestToOldestLink(type?: string): string {
-    const url = '/hashstrikes/blockrate-strikes-range?page=1';
+    const url = '/hashstrikes/blockrate-strikes-by-blockrate-summary?page=1';
 
     if (type) {
       return `${url}&result=${type}`;
@@ -109,7 +109,7 @@ export class PreviewComponent implements OnInit {
   }
 
   guessableStrikeListNewestToOldestLink(): string {
-    return '/hashstrikes/blockrate-strikes-range?outcome=guessable&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?outcome=guessable&page=1';
   }
 
   pastStrikeListQWithGuess(): string {
@@ -117,31 +117,31 @@ export class PreviewComponent implements OnInit {
   }
 
   strikesRangeWithStartblockEndblock(): string {
-    return '/hashstrikes/blockrate-strikes-range?startblock=849237&endblock=849251&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?startblock=849237&endblock=849251&page=1';
   }
 
   strikesRangeWithStarttimeEndtime(): string {
-    return '/hashstrikes/blockrate-strikes-range?startTime=1719194635&endTime=1719201779&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?startTime=1719194635&endTime=1719201779&page=1';
   }
 
   strikesRangeWithStartblockEndtime(): string {
-    return '/hashstrikes/blockrate-strikes-range?startblock=849237&endTime=1719201779&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?startblock=849237&endTime=1719201779&page=1';
   }
 
   strikesRangeWithstarttimeEndBlock(): string {
-    return '/hashstrikes/blockrate-strikes-range?startTime=1719194635&endblock=849251&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?startTime=1719194635&endblock=849251&page=1';
   }
 
   strikesRangeWithLastStrikes(): string {
-    return '/hashstrikes/blockrate-strikes-range?lastStrikes&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?lastStrikes&page=1';
   }
 
   strikesRangeWithNextStrikes(): string {
-    return '/hashstrikes/blockrate-strikes-range?nextStrikes&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?nextStrikes&page=1';
   }
 
   strikeListSortByGuess(): string {
-    return '/hashstrikes/blockrate-strikes-range?sort=descend_guesses_count&page=1';
+    return '/hashstrikes/blockrate-strikes-by-blockrate-summary?sort=descend_guesses_count&page=1';
   }
 
   blockspanDetails(): string {
@@ -180,10 +180,10 @@ export class PreviewComponent implements OnInit {
 
   blockspanSummaryLink(type: 'past' | 'future' = 'future'): string {
     if (type === 'past') {
-      return `/hashstrikes/blockrate-summary?startblock=849237&endblock=849251`;
+      return `/hashstrikes/blockrate-summary?startblock=849237&endblock=849251&format=widget`;
     }
 
-    return `/hashstrikes/blockrate-summary?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}`;
+    return `/hashstrikes/blockrate-summary?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}&format=widget`;
   }
 
   hashrateSummaryLink(type: 'past' | 'future' = 'future'): string {
@@ -191,5 +191,9 @@ export class PreviewComponent implements OnInit {
       return `/hashstrikes/hashrate-summary?startblock=849237&endblock=849251`;
     }
     return `/hashstrikes/hashrate-summary?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}`;
+  }
+
+  endBlockNWithStrikeSummary(): string {
+    return `/hashstrikes/blockrate-summary-endblockmatches?startblock=${this.latestBlock?.height}&endblock=${this.latestStrike?.strike?.block}`;
   }
 }

--- a/frontend/src/app/oe/oe.routing.modules.ts
+++ b/frontend/src/app/oe/oe.routing.modules.ts
@@ -57,7 +57,7 @@ const routes: Routes = [
             component: BlockspansHomeComponent,
           },
           {
-            path: 'blockrate-strikes-range',
+            path: 'blockrate-strikes-by-blockrate-summary',
             component: StrikesRangeComponent,
           },
           {
@@ -78,6 +78,10 @@ const routes: Routes = [
           },
           {
             path: 'blockrate-summary',
+            component: BlockrateSummaryV2Component
+          },
+          {
+            path: 'blockrate-summary-endblockmatches',
             component: BlockrateSummaryV2Component
           },
           {

--- a/frontend/src/app/oe/types/constant.ts
+++ b/frontend/src/app/oe/types/constant.ts
@@ -27,3 +27,8 @@ export enum Logos {
 }
 
 export const GENESIS_K = Math.pow(2, 32) / 600;
+
+export enum FormatType {
+  WIDGET = 'widget',
+  LINE = 'line',
+}

--- a/frontend/src/app/oe/utils/helper.ts
+++ b/frontend/src/app/oe/utils/helper.ts
@@ -85,7 +85,11 @@ export const convertToCSV = (jsonData: any): string => {
   const header = Array.from(keys).join(',');
   const csvRows = rows.map((row) =>
     Array.from(keys)
-      .map((key) => row[key] ?? '')
+      .map((key) => {
+        const value = row[key] ?? '';
+        const safeValue = String(value).replace(/"/g, '""'); // Escape internal quotes
+        return `"${safeValue}"`; // Wrap in double quotes
+      })
       .join(',')
   );
 


### PR DESCRIPTION
This PR introduces a new summary widget screen titled **“Ending in Block N”**, enhances the `blockrate-summary` and the new screen with format flexibility, and updates the URL schema for improved clarity.

✅ **Added New Screen: Ending in Block N**  
- Introduced a new summary widget screen to display strikes ending in a specific block.  
- Integrated this as part of the block rate visualization module.  

✅ **Enhanced Format Support (Widget / Lines)**  
- Added support for dynamic formatting using `format=widget` or `format=lines`.  
- Applied to both `blockrate-summary` and the new `Ending in Block N` screen.  
- Enables flexible UI rendering depending on use case (compact widget vs. detailed view).  

✅ **Updated URL Schema for Range Queries**  
- Changed the route from `/blockrate-strike-range`  
  ➡️ to `/blockrate-strikes-by-blockrate-summary`  
- Reflects more intuitive and consistent naming across the app.