### PR TITLE
Set About Page as Homepage and Add Link to Preview Page

### DIFF
--- a/frontend/src/app/oe/components/about/about.component.html
+++ b/frontend/src/app/oe/components/about/about.component.html
@@ -31,6 +31,10 @@
           target="_blank">FAQ</a>
       </p>
     </div>
+    <div class="mt-1">
+      <p class="mb-0">
+        <a [routerLink]="['/preview-page']">Skunkworks Functionality Preview </a>
+      </p>
+    </div>
   </div>
-
 </div>

--- a/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.html
+++ b/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.html
@@ -1,7 +1,7 @@
 <ng-container>
   <header>
     <nav class="navbar navbar-expand-md navbar-dark bg-dark">
-      <a class="navbar-brand" [routerLink]="['/preview-page']">
+      <a class="navbar-brand" [routerLink]="['/about']">
         <img src="../../../../resources/oe-energy-toolbox.png" class="oe-energy-logo" title="Preview page" />
       </a>
       <div class="navbar-collapse" id="navbarCollapse">

--- a/frontend/src/app/oe/oe.routing.modules.ts
+++ b/frontend/src/app/oe/oe.routing.modules.ts
@@ -24,7 +24,7 @@ import { HashrateSummaryComponent } from './components/hashrate/hashrate-summary
 
 const routes: Routes = [
   { path: 'login/:secret', component: LoginComponent },
-  { path: '', redirectTo: '/preview-page', pathMatch: 'full' },
+  { path: '', redirectTo: '/about', pathMatch: 'full' },
   {
     path: '',
     component: OeMasterPageComponent,


### PR DESCRIPTION
## Summary
This PR updates the routing configuration to set the **About page as the default homepage** and enhances the About page by adding a **navigation link to the Preview page**.

---

## Changes Implemented

✅ **Changed Default Route to About Page**  
- The root URL (`/`) now loads the About page instead of the previous default.

✅ **Added Link to Preview Page in About Page**  
- Included a clear and accessible link/button to navigate from the About page to the Preview page.
