### PR TITLE
 Fix Routing Links for Blockrate Summary and Blockrate Strike Summary Pages

### DIFF
--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.html
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.html
@@ -19,15 +19,36 @@
                     footerText="blocks" [logo]="logos.BLOCKS"></app-box>
                 <div class="blockrate">
                     <a class="dummy"></a>
-                    <div class="to-block oe-link" (click)="goToBlockRateDetails($event)">{{getBlockRate()}}</div>
-                    <div class="footer oe-link" (click)="goToBlockRateDetails($event)">blockrate</div>
-                    <div class="logo oe-link" (click)="goToBlockRateDetails($event)"><span class="logo-container">{{ logos.BLOCKS }}</span></div>
+                    <a class="to-block oe-link" 
+                        [routerLink]="['/hashstrikes/blockspan-details']"
+                        [attr.href]="'/hashstrikes/blockspan-details'"
+                        [queryParams]="{
+                            startblock: fromBlock.height,
+                            endblock: toBlock.height
+                        }">
+                        {{getBlockRate()}}
+                    </a>
+                    <div class="footer">blockrate</div>
+                    <div class="logo">
+                        <span class="logo-container">{{ logos.BLOCKS }}</span>
+                    </div>
                 </div>
                 <div class="hashrate">
                     <a class="dummy"></a>
-                    <div class="to-block oe-link" (click)="goToStrikeDetails($event)">{{getStrikeRate()}}</div>
-                    <div class="footer oe-link" (click)="goToStrikeDetails($event)">predicted blockrate</div>
-                    <div class="logo multiple-logo oe-link" (click)="goToStrikeDetails($event)"><span class="logo-container">{{ logos.BLOCKS }} {{ logos.CONTRACT }}</span></div>
+                    <a class="to-block oe-link" 
+                        [routerLink]="['/hashstrikes/blockrate-strike-details']"
+                        [attr.href]="'/hashstrikes/blockrate-strike-details'"
+                        [queryParams]="{
+                            strikeHeight: strike.block,
+                            strikeTime: strike.strikeMediantime,
+                            startblock: fromBlock.height
+                        }">
+                        {{getStrikeRate()}}
+                    </a>
+                    <div class="footer">predicted blockrate</div>
+                    <div class="logo multiple-logo">
+                        <span class="logo-container">{{ logos.BLOCKS }} {{ logos.CONTRACT }}</span>
+                    </div>
                 </div>
                 <div class="guessing-container">
                     <div class="oe-guessing-box pb-3">

--- a/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.html
+++ b/frontend/src/app/oe/components/blockrate-summary-v2/blockrate-summary-v2.component.html
@@ -13,9 +13,19 @@
                             {{ logos.BLOCKS }}
                         </ng-container>
                     </div>
-                    <div class="to-block oe-link" (click)="goToStrikeDetails($event)">{{getBlockRate()}}</div>
-                    <div class="footer oe-link" (click)="goToStrikeDetails($event)">blockrate</div>
-                    <div class="logo oe-link" (click)="goToStrikeDetails($event)"><span class="logo-container">{{ logos.BLOCKS }}</span></div>
+                    <a class="to-block oe-link" 
+                        [routerLink]="['/hashstrikes/blockspan-details']"
+                        [attr.href]="'/hashstrikes/blockspan-details'"
+                        [queryParams]="{
+                            startblock: fromBlock.height,
+                            endblock: toBlock.height
+                        }">
+                        {{getBlockRate()}}
+                    </a>
+                    <div class="footer">blockrate</div>
+                    <div class="logo">
+                        <span class="logo-container">{{ logos.BLOCKS }}</span>
+                    </div>
                 </div>
                 <div class="guessing-container" *ngIf="format === 'widget'">
                     <div class="oe-message-container">

--- a/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
+++ b/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
@@ -44,7 +44,7 @@ export class StrikesRangeComponent implements OnInit {
     outcome: 'class',
     result: 'observedResultEQ',
   };
-  currentTip = null;
+  currentTip: number;
   linesPerPage = 15;
 
   constructor(
@@ -157,7 +157,7 @@ export class StrikesRangeComponent implements OnInit {
     const queryParams = {
       strikeHeight: item.block,
       strikeTime: item.strikeMediantime,
-      startblock: item.block - 14,
+      startblock: Math.min(this.currentTip, item.block - 14),
     };
 
     if (this.guessableScreen) {
@@ -168,6 +168,8 @@ export class StrikesRangeComponent implements OnInit {
     }
 
     // Use the Router service to navigate with query parameters
-    this.router.navigate(['/hashstrikes/blockrate-strike-details'], { queryParams });
+    this.router.navigate(['/hashstrikes/blockrate-strike-details'], {
+      queryParams,
+    });
   }
 }


### PR DESCRIPTION
This PR resolves routing issues for the **Blockrate Summary** and **Blockrate Strike Summary** pages by updating Angular links to use proper `[routerLink]` bindings along with `href` attributes for full link behavior.

---

## Changes Implemented

✅ **Fixed `[routerLink]` and `queryParams` bindings**  
- Ensured routes navigate correctly without full page reloads.  
- Applied clean binding without trailing commas to avoid Angular template errors.

✅ **Added `href` attributes for improved UX**  
- Users can now:
  - See the destination URL on hover
  - Use right-click > “Copy link” as expected
- Behavior now matches that of traditional links while retaining Angular routing.