### PR TITLE
This PR introduces a reusable judgement-block Angular component and updates the global proxy configuratio

### DIFF
--- a/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.html
+++ b/frontend/src/app/oe/components/block-rate-strike-details-v2/block-rate-strike-details-v2.component.html
@@ -69,48 +69,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="judgement-block-container">
-                    <!-- Top Section -->
-                    <div class="top-blocks">
-                        <!-- Yellow Block -->
-                        <div class="judgement-block yellow-block label">
-                            Judgement block height
-                        </div>
-                        <!-- Orange Block -->
-                        <div class="judgement-block orange-block label">
-                            Judgement block time
-                        </div>
-
-                        <!-- Middle Section: Hash Block -->
-                        <div class="judgement-block hash-block label">
-                            Judgement block hash
-                        </div>
-                    </div>
-                    <div class="top-blocks">
-                        <!-- Yellow Block -->
-                        <div class="judgement-block yellow-block">
-                            {{strike.observedBlockHeight || '?'}}
-                        </div>
-                        <!-- Orange Block -->
-                        <div class="judgement-block orange-block">
-                            {{strike.observedBlockMediantime || '?'}}
-                        </div>
-
-                        <!-- Middle Section: Hash Block -->
-                        <div class="judgement-block hash-block" [ngClass]="{'small-font': strike.observedBlockHash}">
-                            {{strike.observedBlockHash || '?'}}
-                        </div>
-                    </div>
-
-                    <div class="judgement-placeholder">
-                        <div class="label mt-2 text-center">
-                            judgement blockHeight >= StrikeHeight: {{getJudgementHeight()}}
-                        </div>
-                        <div class="label mt-2 text-center">
-                            judgement blockTime >= StrikeTime: {{getJudgementTime()}}
-                        </div>
-                    </div>
-                </div>
+                <app-judgement-block [strike]="strike"></app-judgement-block>
             </div>
         </div>
     </div>

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.html
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.html
@@ -77,6 +77,9 @@
                     </div>
                 </div>
             </div>
+            <div class="judgement-block-summary-wrapper">
+                <app-judgement-block [strike]="strike"></app-judgement-block>
+            </div>
         </div>
     </div>
 </div>

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.scss
@@ -208,3 +208,9 @@
       }
     }
   }
+
+  .judgement-block-summary-wrapper {
+    margin-top: -10px;
+    display: flex;
+    justify-content: center;
+  }

--- a/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.ts
+++ b/frontend/src/app/oe/components/blockrate-strike-summary-v2/blockrate-strike-summary-v2.component.ts
@@ -5,7 +5,7 @@ import {
   BlockTimeStrikePublic,
   PaginationResponse,
 } from '../../interfaces/oe-energy.interface';
-import { BlockTypes, Logos } from '../../types/constant';
+import { APP_CONFIGURATION, BlockTypes, Logos } from '../../types/constant';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import {
   OeBlocktimeApiService,
@@ -102,7 +102,7 @@ export class BlockrateStrikeSummaryV2Component implements OnInit {
           }
 
           if (!fromBlockHeight) {
-            fromBlockHeight = Math.max(0, strikeHeight - 14);
+            fromBlockHeight = Math.max(0, strikeHeight - APP_CONFIGURATION.SPAN_SIZE);
           }
           // Creating temporary strike
           this.strike = {

--- a/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
+++ b/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Input, OnInit, Renderer2 } from '@angular/core';
 import { Block } from '../../interfaces/oe-energy.interface';
-import { BlockTypes, Logos } from '../../types/constant';
+import { APP_CONFIGURATION, BlockTypes, Logos } from '../../types/constant';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { OeEnergyApiService } from '../../services/oe-energy.service';
 import { OeStateService } from '../../services/state.service';
@@ -82,7 +82,7 @@ export class BlockspanBHSComponent implements OnInit {
               : parseInt(startBlock, 10) || this.latestBlock.height;
 
           const toBlockHeight: number =
-            parseInt(endBlock, 10) || (startBlock ? +startBlock + 14 : 1200000);
+            parseInt(endBlock, 10) || (startBlock ? +startBlock + APP_CONFIGURATION.SPAN_SIZE : 1200000);
 
           this.fromBlock = undefined;
           this.toBlock = undefined;

--- a/frontend/src/app/oe/components/blockspan/blockspan.component.ts
+++ b/frontend/src/app/oe/components/blockspan/blockspan.component.ts
@@ -9,7 +9,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Block } from '../../interfaces/oe-energy.interface';
 import { navigator } from '../../utils/helper';
 
-export const MAX_COUNT = 14;
 @Component({
   selector: 'app-blockspan',
   templateUrl: './blockspan.component.html',

--- a/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
+++ b/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
@@ -22,6 +22,7 @@ import { Block } from '../../interfaces/oe-energy.interface';
 import { OeEnergyApiService } from '../../services/oe-energy.service';
 import { environment } from '../../../../environments/environment';
 import { getBlockSpanByHeight } from '../../utils/helper';
+import { APP_CONFIGURATION } from '../../types/constant';
 
 interface PastBlock extends Block {
   mediantimeDiff: number;
@@ -96,7 +97,7 @@ export class BlockspansHomeComponent implements OnInit, OnDestroy {
                 .pipe(
                   switchMap((block: Block) =>
                     of({
-                      from: block.height - 14,
+                      from: block.height - APP_CONFIGURATION.SPAN_SIZE,
                       to: block.height,
                     })
                   )

--- a/frontend/src/app/oe/components/energy-summary/energy-summary.component.ts
+++ b/frontend/src/app/oe/components/energy-summary/energy-summary.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { switchMap, catchError, take } from 'rxjs/operators';
 import { combineLatest, of, Subscription } from 'rxjs';
-import { BlockTypes } from '../../types/constant';
+import { APP_CONFIGURATION, BlockTypes } from '../../types/constant';
 import {
   Block,
   BlockTimeStrikePublic,
@@ -75,7 +75,7 @@ export class EnergySummaryComponent implements OnInit, OnDestroy {
             endBlock && startBlock
               ? parseInt(startBlock, 10)
               : endBlock
-              ? parseInt(endBlock, 10) - 14
+              ? parseInt(endBlock, 10) - APP_CONFIGURATION.SPAN_SIZE
               : parseInt(startBlock, 10) || this.latestBlock.height;
 
           const toBlockHeight: number =

--- a/frontend/src/app/oe/components/judgement-block/judgement-block.component.html
+++ b/frontend/src/app/oe/components/judgement-block/judgement-block.component.html
@@ -1,0 +1,35 @@
+<div class="judgement-block-container">
+  <div class="top-blocks">
+    <div class="judgement-block yellow-block label">
+      Judgement block height
+    </div>
+    <div class="judgement-block orange-block label">
+      Judgement block time
+    </div>
+    <div class="judgement-block hash-block label">
+      Judgement block hash
+    </div>
+  </div>
+  <div class="top-blocks">
+    <div class="judgement-block yellow-block">
+      {{strike?.observedBlockHeight || '?'}}
+    </div>
+    <div class="judgement-block orange-block">
+      {{strike?.observedBlockMediantime || '?'}}
+    </div>
+    <div class="judgement-block hash-block" [ngClass]="{'small-font': strike?.observedBlockHash}">
+      {{strike?.observedBlockHash || '?'}}
+    </div>
+  </div>
+  <div class="judgement-placeholder">
+    <div class="label mt-2 text-center">
+      judgement blockHeight >= StrikeHeight: {{getJudgementHeight()}}
+    </div>
+    <div class="label mt-2 text-center">
+      judgement blockTime >= StrikeTime: {{getJudgementTime()}}
+    </div>
+     <div class="label mt-2 mb-2 text-center">
+      judgement: {{getResult()}}
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/oe/components/judgement-block/judgement-block.component.scss
+++ b/frontend/src/app/oe/components/judgement-block/judgement-block.component.scss
@@ -1,0 +1,68 @@
+.judgement-block-container {
+  width: 95%;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 18px;
+  font-weight: 700;
+  color: black;
+  margin-left: 0.5rem;
+  margin-top: 2rem;
+
+  .top-blocks {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    gap: 0.5rem;
+
+    .judgement-block {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      border: 2px solid black;
+      padding: 1rem;
+      text-align: center;
+    }
+
+    .yellow-block {
+      background-color: yellow;
+      width: 15rem;
+      height: 6rem;
+    }
+
+    .orange-block {
+      background-color: orange;
+      width: 15rem;
+      height: 6rem;
+    }
+
+    .hash-block {
+      background-color: #d5a6bd;
+      width: 32.75rem;
+      height: 6rem;
+      border: 2px solid black;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
+
+    .label {
+      background-color: unset;
+      color: white;
+      border: none;
+    }
+
+    .small-font{
+      font-size: 0.75rem;
+    }
+  }
+
+  .judgement-placeholder {
+    display: flex;
+    flex-direction: column;
+    color: white;
+  }
+}

--- a/frontend/src/app/oe/components/judgement-block/judgement-block.component.ts
+++ b/frontend/src/app/oe/components/judgement-block/judgement-block.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-judgement-block',
+  templateUrl: './judgement-block.component.html',
+  styleUrls: ['./judgement-block.component.scss']
+})
+export class JudgementBlockComponent {
+  @Input() strike: any;
+
+  getJudgementHeight(): boolean | undefined {
+    if (!this.strike?.observedBlockHeight) return;
+    return this.strike.observedBlockHeight > this.strike.block - 1;
+  }
+
+  getJudgementTime(): boolean | undefined {
+    if (!this.strike?.observedBlockMediantime) return;
+    return this.strike.observedBlockMediantime > this.strike.strikeMediantime;
+  }
+
+   getResult(): string {
+    if (!this.strike.observedBlockHeight) return;
+
+    const heightOverStrikeHeight = this.getJudgementHeight();
+    const timeOverStrikeTime = this.getJudgementTime();
+
+    if (heightOverStrikeHeight && !timeOverStrikeTime) return 'fast';
+
+    if (!heightOverStrikeHeight && timeOverStrikeTime) return 'slow';
+
+    return 'slow';
+  }
+
+}

--- a/frontend/src/app/oe/components/my-guesses/my-guesses.component.ts
+++ b/frontend/src/app/oe/components/my-guesses/my-guesses.component.ts
@@ -6,6 +6,7 @@ import {
   OeBlocktimeApiService,
 } from '../../services/oe-energy.service';
 import { BlockTimeStrikeGuessPublic } from '../../interfaces/oe-energy.interface';
+import { APP_CONFIGURATION } from '../../types/constant';
 
 @Component({
   selector: 'app-my-guesses',
@@ -71,7 +72,7 @@ export class MyGuessesComponent implements OnInit {
 
     // Only add blockspanStart if the result is known (observedResult is not null or empty)
     if (observedResult) {
-      queryParams.blockspanStart = strikeHeight - 14; // 14 blocks before the current strike height
+      queryParams.blockspanStart = strikeHeight - APP_CONFIGURATION.SPAN_SIZE; // span blocks before the current strike height
     }
 
     // Navigate to the target route with the query parameters

--- a/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
+++ b/frontend/src/app/oe/components/strikes-range/strikes-range.component.ts
@@ -14,6 +14,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { Subscription, take } from 'rxjs';
 import { OeStateService } from '../../services/state.service';
+import { APP_CONFIGURATION } from '../../types/constant';
 
 @Component({
   selector: 'app-strikes-range',
@@ -157,7 +158,7 @@ export class StrikesRangeComponent implements OnInit {
     const queryParams = {
       strikeHeight: item.block,
       strikeTime: item.strikeMediantime,
-      startblock: Math.min(this.currentTip, item.block - 14),
+      startblock: Math.min(this.currentTip, item.block - APP_CONFIGURATION.SPAN_SIZE),
     };
 
     if (this.guessableScreen) {

--- a/frontend/src/app/oe/oe.module.ts
+++ b/frontend/src/app/oe/oe.module.ts
@@ -58,6 +58,7 @@ import { BlockrateStrikeSummaryV2Component } from './components/blockrate-strike
 import { BlockrateSummaryV2Component } from './components/blockrate-summary-v2/blockrate-summary-v2.component';
 import { HashrateComponent } from './components/hashrate/hashrate-details/hashrate.component';
 import { HashrateSummaryComponent } from './components/hashrate/hashrate-summary/hashrate-summary.component';
+import { JudgementBlockComponent } from './components/judgement-block/judgement-block.component';
 
 @NgModule({
   declarations: [
@@ -98,6 +99,7 @@ import { HashrateSummaryComponent } from './components/hashrate/hashrate-summary
     BlockrateSummaryV2Component,
     HashrateComponent,
     HashrateSummaryComponent,
+    JudgementBlockComponent,
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/oe/types/constant.ts
+++ b/frontend/src/app/oe/types/constant.ts
@@ -32,3 +32,7 @@ export enum FormatType {
   WIDGET = 'widget',
   LINE = 'line',
 }
+
+export const APP_CONFIGURATION = {
+  SPAN_SIZE: 14,
+};

--- a/frontend/src/app/oe/utils/helper.ts
+++ b/frontend/src/app/oe/utils/helper.ts
@@ -1,5 +1,6 @@
 import { Router } from '@angular/router';
 import { Block, BlockHeader } from '../interfaces/oe-energy.interface';
+import { APP_CONFIGURATION } from '../types/constant';
 
 export function navigator(router: Router, link: string): void {
   // Check if the link contains query parameters
@@ -134,7 +135,7 @@ export const convertHashrate = (
 export const getBlockSpanByHeight = (
   tipBlock: number,
   noOfBlock: number,
-  span = 14
+  span = APP_CONFIGURATION.SPAN_SIZE
 ): { fromBlock: number; toBlock: number } => {
   const fromBlock = tipBlock - span * noOfBlock;
   return {


### PR DESCRIPTION
This PR introduces a reusable judgement-block Angular component and updates the global proxy configuration.

Changes Implemented
✅ Created judgement-block component

- Extracted the judgement block UI and logic from the Blockrate Strike Details and Summary pages into a standalone, reusable Angular component.
- Moved all related calculation logic and markup into the new component for better maintainability and reusability.
- Updated parent components to use  reusable component for a cleaner template and improved code organization.
- Applied consistent styles by migrating relevant SCSS from the old implementation.

✅ Moved hard coded span to global constant