### PR TITLE
Switch frontend to use V2 blockspan API endpoints

### DIFF
--- a/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
+++ b/frontend/src/app/oe/components/blockspan-bhs/blockspan-bhs.component.ts
@@ -89,14 +89,16 @@ export class BlockspanBHSComponent implements OnInit {
 
           this.isLoadingBlock = true;
 
-          return combineLatest([
-            this.oeEnergyApiService
-              .$getBlockByHeight(fromBlockHeight)
-              .pipe(catchError(() => of(getEmptyBlockHeader(fromBlockHeight)))),
-            this.oeEnergyApiService
-              .$getBlockByHeight(toBlockHeight)
-              .pipe(catchError(() => of(getEmptyBlockHeader(toBlockHeight)))),
-          ]);
+          return this.oeEnergyApiService
+            .$getBlocksByHeights([fromBlockHeight, toBlockHeight])
+            .pipe(
+              catchError(() =>
+                of([
+                  getEmptyBlockHeader(fromBlockHeight),
+                  getEmptyBlockHeader(toBlockHeight),
+                ])
+              )
+            );
         })
       )
       .subscribe(([fromBlock, toBlock]: [Block, Block]) => {

--- a/frontend/src/app/oe/components/energy-detail/energy-detail.component.ts
+++ b/frontend/src/app/oe/components/energy-detail/energy-detail.component.ts
@@ -106,14 +106,9 @@ export class EnergyDetailComponent implements OnInit, OnDestroy {
             if (fromBlockInCache && toBlockInCache) {
               return of([fromBlockInCache, toBlockInCache]);
             }
-            return combineLatest([
-              this.oeEnergyApiService
-                .$getBlockByHeight(fromBlockHeight)
-                .pipe(catchError(() => of(fromBlockHeight))),
-              this.oeEnergyApiService
-                .$getBlockByHeight(toBlockHeight)
-                .pipe(catchError(() => of(toBlockHeight))),
-            ]);
+            return this.oeEnergyApiService
+              .$getBlocksByHeights([fromBlockHeight, toBlockHeight])
+              .pipe(catchError(() => of([fromBlockHeight, toBlockHeight])));
           }
         })
       )

--- a/frontend/src/app/oe/components/energy-summary/energy-summary.component.ts
+++ b/frontend/src/app/oe/components/energy-summary/energy-summary.component.ts
@@ -112,16 +112,16 @@ export class EnergySummaryComponent implements OnInit, OnDestroy {
               return of([fromBlockInCache, toBlockInCache]);
             }
 
-            return combineLatest([
-              this.oeEnergyApiService
-                .$getBlockByHeight(fromBlockHeight)
-                .pipe(
-                  catchError(() => of(getEmptyBlockHeader(fromBlockHeight)))
-                ),
-              this.oeEnergyApiService
-                .$getBlockByHeight(toBlockHeight)
-                .pipe(catchError(() => of(getEmptyBlockHeader(toBlockHeight)))),
-            ]);
+            return this.oeEnergyApiService
+              .$getBlocksByHeights([fromBlockHeight, toBlockHeight])
+              .pipe(
+                catchError(() =>
+                  of([
+                    getEmptyBlockHeader(fromBlockHeight),
+                    getEmptyBlockHeader(toBlockHeight),
+                  ])
+                )
+              );
           }
         })
       )

--- a/frontend/src/app/oe/components/hashrate/hashrate-details/hashrate.component.ts
+++ b/frontend/src/app/oe/components/hashrate/hashrate-details/hashrate.component.ts
@@ -100,14 +100,16 @@ export class HashrateComponent implements OnInit {
 
           this.isLoadingBlock = true;
 
-          return combineLatest([
-            this.oeEnergyApiService
-              .$getBlockByHeight(fromBlockHeight)
-              .pipe(catchError(() => of(getEmptyBlockHeader(fromBlockHeight)))),
-            this.oeEnergyApiService
-              .$getBlockByHeight(toBlockHeight)
-              .pipe(catchError(() => of(getEmptyBlockHeader(toBlockHeight)))),
-          ]);
+          return this.oeEnergyApiService
+            .$getBlocksByHeights([fromBlockHeight, toBlockHeight])
+            .pipe(
+              catchError(() =>
+                of([
+                  getEmptyBlockHeader(fromBlockHeight),
+                  getEmptyBlockHeader(toBlockHeight),
+                ])
+              )
+            );
         })
       )
       .subscribe(([fromBlock, toBlock]: [Block, Block]) => {

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   baseUrl: 'https://exchange.op-energy.info',
-  KEEP_BLOCKS_AMOUNT: 11
+  KEEP_BLOCKS_AMOUNT: 11,
+  useV2BlockspanApi: false // Set to true to enable V2 blockspan APIs
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   baseUrl: 'https://exchange.op-energy.info',
-  KEEP_BLOCKS_AMOUNT: 11
+  KEEP_BLOCKS_AMOUNT: 11,
+  useV2BlockspanApi: true // Set to true to enable V2 blockspan APIs
 };


### PR DESCRIPTION
- Updated oe-energy.service to use V2 blockspan API calls
- Modified all blockspan components to use V2 endpoints when flag is enabled
- Added useV2BlockspanApi flag to environment configurations
- Refactored BaseBlockComponent to handle V2 API responses
- Updated components: strike-summary, strike-detail, hashrate, blockspan-bhs, energy-summary, energy-detail