### PR TITLE
Refactor V2.getSingleBlockspan to ExceptT transformer

### DIFF
--- a/op-energy-backend/derivation.nix
+++ b/op-energy-backend/derivation.nix
@@ -22,6 +22,7 @@
 , wai-middleware-prometheus
 , GIT_COMMIT_HASH
 , persistent-pagination
+, safe-exceptions
 , ...
 }:
 
@@ -54,6 +55,7 @@ mkDerivation {
     prometheus-proc
     wai-middleware-prometheus
     persistent-pagination
+    safe-exceptions
   ];
   preBuild = ''
     sed -i 's/GIT_COMMIT_HASH/${GIT_COMMIT_HASH}/' src/OpEnergy/Server/GitCommitHash.hs

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -108,6 +108,7 @@ library
                     , ghc-compact
                     , resourcet
                     , persistent-pagination
+                    , safe-exceptions
 
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
     extensions:       OverloadedStrings

--- a/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
@@ -91,10 +91,8 @@ profile
   -> AppT m r
 profile name next = do
   metricsV <- asks metrics
-  callstackV <- asks callStack
-  let
-      newCallStack = callstackV <> "." <> name
+  newCallStack <- asks $! (<> "." <> name) . callStack
   local (\r-> r{ callStack = newCallStack}) $ do
-    histogram <- liftIO $ dynamicHistogram (dynamicHistograms metricsV) callstackV
+    histogram <- liftIO $ dynamicHistogram (dynamicHistograms metricsV) newCallStack
     P.observeDuration histogram next
 

--- a/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
@@ -3,9 +3,11 @@
  -}
 module OpEnergy.Server.V1.Class where
 
+import           Data.Text(Text)
 import           Control.Concurrent.STM.TVar (TVar)
 import qualified Control.Concurrent.STM.TVar as TVar
-import           Control.Monad.Trans.Reader (runReaderT, ReaderT, ask)
+import           Control.Monad.Trans.Reader
+                 (runReaderT, ReaderT, ask, asks, local)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Trans(lift)
 import           Control.Monad.Logger (runLoggingT, filterLogger, LoggingT, MonadLoggerIO, Loc, LogSource, LogLevel, LogStr)
@@ -14,7 +16,9 @@ import           Servant (Handler)
 import           Data.Pool(Pool)
 import           Database.Persist.Postgresql (SqlBackend)
 import           System.IO(hFlush, stdout)
+
 import           Prometheus(MonadMonitor(..))
+import qualified Prometheus as P
 
 import           Data.OpEnergy.API.V1.Block ( BlockHeader)
 import           OpEnergy.Server.V1.Config
@@ -40,6 +44,8 @@ data State = State
   , logLevel :: TVar LogLevel
   , metrics :: MetricsState
   -- ^ contains metrics handlers
+  , callStack :: Text
+    -- ^ dot-separated call stack
   }
 
 type AppT = ReaderT State
@@ -60,6 +66,7 @@ defaultState config metrics logFunc _blockHeadersDBPool = do
     , logFunc = logFunc
     , logLevel = logLevelV
     , metrics = metrics
+    , callStack = ""
     }
 
 -- | Runs app transformer with given context
@@ -73,3 +80,21 @@ runLogging loggingAction = do
   _ <- lift $ runLoggingT (filterLogger filterUnwantedLevels loggingAction) logFunc
   liftIO $ hFlush stdout
   return ()
+
+-- | this function profiles execution of the provided function
+profile
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => Text
+  -> AppT m r
+  -> AppT m r
+profile name next = do
+  metricsV <- asks metrics
+  callstackV <- asks callStack
+  let
+      newCallStack = callstackV <> "." <> name
+  local (\r-> r{ callStack = newCallStack}) $ do
+    histogram <- liftIO $ dynamicHistogram (dynamicHistograms metricsV) callstackV
+    P.observeDuration histogram next
+


### PR DESCRIPTION
This PR contains:
1. refactor of the V2.getSingleBlockspan function which will now wrap possible exceptions into ExceptT transformer in order to catch exceptions explicitely;
2. proper implementation of the 'profile' function, which introduces dynamic profile of the nested function (which decrease complexity of adding profiling to a function);
3. refactor neighbor functions to use profile and ExceptT transformer
4. rename qualified imports in order to reduce length of the function calls