### PR TITLE
fix: fix the second part of the blockspans V2 API routing

### DIFF
--- a/frontend/module-frontend.nix
+++ b/frontend/module-frontend.nix
@@ -243,7 +243,7 @@ in
           }
           location /api/v2/blockspans {
                   limit_req zone=api burst=10 nodelay;
-                  proxy_pass ${cfg.mainnet_api_host}/api/v2;
+                  proxy_pass ${cfg.mainnet_api_host}/api/v2/blockspans;
           }
           location /api/v1 {
                   limit_req zone=api burst=10 nodelay;


### PR DESCRIPTION
This PR is the follow up to https://github.com/op-energy-foundation/op-energy-blockspan-service/pull/127 which contain my suggestion to specialize the routing, but I missed the second part which required specialization as well