### PR TITLE
feat: pin nixpkgs for build reproducibility purposes

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,1 @@
+fetchTarball "https://github.com/NixOS/nixpkgs/archive/4d2b37a84fad1091b9de401eb450aae66f1a741e.tar.gz"

--- a/op-energy-api/default.nix
+++ b/op-energy-api/default.nix
@@ -1,0 +1,6 @@
+let
+  stable = import ../nixpkgs.nix;
+  pkgs0 = (import stable {}); # first, load the nixpkgs with system-wide overlays
+  pkgs = pkgs0 // (import ./overlay-set.nix { pkgs = pkgs0; }); # second, add local packages into the scope of pkgs
+
+in pkgs.op-energy-api

--- a/op-energy-api/shell.nix
+++ b/op-energy-api/shell.nix
@@ -1,5 +1,6 @@
 let
-  pkgs0 = (import <nixpkgs> {}); # first, load the nixpkgs with system-wide overlays
+  stable = import ../nixpkgs.nix;
+  pkgs0 = (import stable {}); # first, load the nixpkgs with system-wide overlays
   pkgs = pkgs0 // (import ./overlay-set.nix { pkgs = pkgs0; }); # second, add local packages into the scope of pkgs
   shell = pkgs.stdenv.mkDerivation {
     name = "shell";

--- a/op-energy-backend/shell.nix
+++ b/op-energy-backend/shell.nix
@@ -1,6 +1,7 @@
 let
+  stable = import ../nixpkgs.nix;
   overlay = import ../overlay.nix { GIT_COMMIT_HASH = "";};
-  pkgs = (import <nixpkgs> {
+  pkgs = (import stable {
     overlays = [ overlay ];
   }); # first, load the nixpkgs with system-wide overlays
   shell = pkgs.stdenv.mkDerivation {

--- a/overlay-set.nix
+++ b/overlay-set.nix
@@ -4,8 +4,8 @@ let
   op-energy-backend-overlay = import ./op-energy-backend/overlay.nix {
     GIT_COMMIT_HASH = GIT_COMMIT_HASH;
   };
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/4d2b37a84fad1091b9de401eb450aae66f1a741e.tar.gz";
-  pkgs = import nixpkgs {
+  stable = import ./nixpkgs.nix;
+  pkgs = import stable {
     config = {};
     overlays = [
       op-energy-api-overlay


### PR DESCRIPTION
This PR contains pinned nixpkgs for reproducible builds.

Main purpose are:

- to be able to build and deploy op-energy on a current NixOS version without rewriting big portion of code due to dependencies updates;
- to update instances to the current nixos versions;
- to be able to update op-energy dependencies in the future.