### PR TITLE
Disable deprecated v1 APIs and track v1/v2 traffic (#120)

### DIFF
--- a/op-energy-backend/derivation.nix
+++ b/op-energy-backend/derivation.nix
@@ -6,6 +6,8 @@
 , bytestring
 , lens
 , warp
+, wai
+, http-types
 , scientific
 , persistent, persistent-template, persistent-postgresql, monad-logger
 , resource-pool
@@ -49,6 +51,8 @@ mkDerivation {
     stm stm-chans
     transformers
     warp
+    wai
+    http-types
     monad-logger
     prometheus-client
     prometheus-metrics-ghc

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -97,6 +97,8 @@ library
                     , stm, stm-chans
                     , transformers
                     , warp
+                    , wai
+                    , http-types
                     , monad-logger
                     , prometheus-client
                     , wai-middleware-prometheus

--- a/op-energy-backend/src/OpEnergy/Server.hs
+++ b/op-energy-backend/src/OpEnergy/Server.hs
@@ -12,8 +12,12 @@
 module OpEnergy.Server where
 
 import           System.IO as IO
+import           Data.Text (Text)
 import           Servant ( Application, Proxy(..), ServerT, serve, hoistServer, (:<|>)(..))
+import           Network.Wai (Middleware, Response, pathInfo, responseLBS)
 import           Network.Wai.Handler.Warp(run)
+import           Network.HTTP.Types (status410, hContentType)
+import qualified Prometheus as P
 import           Control.Monad.Trans.Reader (ask)
 import           Control.Concurrent (threadDelay)
 import           Control.Monad.IO.Class(liftIO, MonadIO)
@@ -57,12 +61,81 @@ initState config = do
   state <- defaultState config metrics logFunc pool
   return (state, prometheusA)
 
+-- | Deprecated v1 path prefixes that have a v2 equivalent. Requests to these
+-- paths are disabled (reply with HTTP 410 Gone) when configDisableDeprecatedV1Api
+-- is True, pointing the caller at the v2 endpoint. The v1 WebSocket (api/v1/ws)
+-- is included because the frontend has migrated to the v2 WebSocket
+-- (api/v2/blockspans/ws).
+deprecatedV1WithSuccessorPrefixes :: [[Text]]
+deprecatedV1WithSuccessorPrefixes =
+  [ ["api", "v1", "blockspans", "statistics"]
+  , ["api", "v1", "oe", "block"]
+  , ["api", "v1", "oe", "blockbyheight"]
+  , ["api", "v1", "oe", "blocksbyblockspan"]
+  , ["api", "v1", "oe", "blockswithnbdrbyblockspan"]
+  , ["api", "v1", "oe", "git-hash"]
+  , ["api", "v1", "ws"]
+  ]
+
+-- | Deprecated v1 path prefixes that have NO v2 equivalent. They are disabled
+-- (reply with HTTP 410 Gone) when configDisableDeprecatedV1Api is True because
+-- they are unused by the frontend; since there is no successor, the reply does
+-- not point at a v2 endpoint.
+deprecatedV1NoSuccessorPrefixes :: [[Text]]
+deprecatedV1NoSuccessorPrefixes =
+  [ ["api", "v1", "oe", "blockswithhashratebyblockspan"]
+  , ["api", "v1", "oe", "blockspanlist"]
+  ]
+
+-- | returns API version ("v1"/"v2") of a request path, if the request targets one
+apiVersionOfPath :: [Text] -> Maybe Text
+apiVersionOfPath (root : version : _)
+  | root == "api" && version == "v1" = Just "v1"
+  | root == "api" && version == "v2" = Just "v2"
+apiVersionOfPath _ = Nothing
+
+-- | True when the request path matches one of the given path prefixes
+matchesAnyPrefix :: [[Text]] -> [Text] -> Bool
+matchesAnyPrefix prefixes segments =
+  any (\prefix -> prefix == take (length prefix) segments) prefixes
+
+-- | returns the HTTP 410 Gone response for a disabled deprecated v1 path, or
+-- Nothing when the path is not a disabled v1 endpoint
+disabledV1GoneResponse :: [Text] -> Maybe Response
+disabledV1GoneResponse segments
+  | matchesAnyPrefix deprecatedV1WithSuccessorPrefixes segments =
+      Just $ goneResponse "This v1 endpoint is deprecated and has been disabled. Please use the corresponding v2 endpoint."
+  | matchesAnyPrefix deprecatedV1NoSuccessorPrefixes segments =
+      Just $ goneResponse "This v1 endpoint is deprecated and has been disabled."
+  | otherwise = Nothing
+  where
+    goneResponse msg = responseLBS status410
+      [(hContentType, "application/json;charset=utf-8")]
+      ("{\"error\":\"" <> msg <> "\"}")
+
+-- | WAI middleware handling the v1 -> v2 migration concerns:
+--   1. counts every /api/v1 and /api/v2 request into a prometheus counter,
+--      labeled by version, so that v1-vs-v2 traffic can be tracked
+--   2. replies with HTTP 410 Gone for deprecated v1 endpoints when they have
+--      been disabled via configDisableDeprecatedV1Api
+apiMigrationMiddleware :: State -> Middleware
+apiMigrationMiddleware s app req respond = do
+  let segments = pathInfo req
+      Config{ configDisableDeprecatedV1Api = disabled } = config s
+      MetricsState{ apiVersionRequests = apiVersionRequests } = metrics s
+  case apiVersionOfPath segments of
+    Just version -> P.withLabel apiVersionRequests version P.incCounter
+    Nothing -> return ()
+  case (disabled, disabledV1GoneResponse segments) of
+    (True, Just goneResponse) -> respond goneResponse
+    _ -> app req respond
+
 -- | Runs HTTP server on a port defined in config in the State datatype
 runServer :: (MonadIO m) => AppT m ()
 runServer = do
   s <- ask
   let port = configHTTPAPIPort (config s)
-  liftIO $ run port (app s)
+  liftIO $ run port (apiMigrationMiddleware s (app s))
   where
     app :: State-> Application
     app s = serve api $ hoistServer api (runAppT s) serverSwaggerBackend

--- a/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
@@ -63,6 +63,12 @@ data Config = Config
     -- ^ defines minimum size of blockspan
   , configRecordsPerReply :: Positive Int
     -- ^ defines how many rows shoud be contained within 1 page of the reply/request
+  , configDisableDeprecatedV1Api :: Bool
+    -- ^ when True (the default), deprecated v1 endpoints that have a v2 equivalent
+    -- are disabled and reply with HTTP 410 Gone. v1 endpoints without a v2
+    -- equivalent are unaffected. Set DISABLE_DEPRECATED_V1_API=false in the config
+    -- to keep serving v1 (e.g. temporarily in an environment) without removing any
+    -- handler code.
   }
   deriving Show
 instance FromJSON Config where
@@ -88,6 +94,7 @@ instance FromJSON Config where
     <*> ( v .:? "CACHE_CHUNK_SIZE" .!= (configCacheChunkSize defaultConfig))
     <*> ( v .:? "BLOCKSPAN_MINIMUM_SIZE" .!= (configBlockspanMinimumSize defaultConfig))
     <*> ( v .:? "RECORDS_PER_REPLY" .!= (configRecordsPerReply defaultConfig))
+    <*> ( v .:? "DISABLE_DEPRECATED_V1_API" .!= (configDisableDeprecatedV1Api defaultConfig))
 
 defaultConfig:: Config
 defaultConfig = Config
@@ -112,6 +119,7 @@ defaultConfig = Config
   , configCacheChunkSize = 50000
   , configBlockspanMinimumSize = 6
   , configRecordsPerReply = 1000
+  , configDisableDeprecatedV1Api = True
   }
 
 getConfigFromEnvironment :: IO Config

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -55,6 +55,9 @@ data MetricsState = MetricsState
   , getBlocksWithNbdrByBlockSpan :: P.Histogram
   , getBlocksWithHashrateByBlockSpan :: P.Histogram
   , getSingleBlockspan :: P.Histogram
+    -- counts incoming HTTP API requests, labeled by API version ("v1"/"v2"),
+    -- so that v1-vs-v2 traffic can be tracked during the migration
+  , apiVersionRequests :: P.Vector P.Label1 P.Counter
     -- for dynamic routines
   , dynamicHistograms :: TVar (Map Text P.Histogram)
   }
@@ -90,6 +93,9 @@ initMetrics _config = do
   getBlocksWithNbdrByBlockSpan <- P.register $ P.histogram (P.Info "getBlocksWithNbdrByBlockSpan" "") microBuckets
   getBlocksWithHashrateByBlockSpan <- P.register $ P.histogram (P.Info "getBlocksWithHashrateByBlockSpan" "") microBuckets
   getSingleBlockspan <- P.register $ P.histogram (P.Info "getSingleBlockspan" "") microBuckets
+  apiVersionRequests <- P.register
+    $ P.vector "version"
+    $ P.counter (P.Info "api_requests_total" "number of HTTP API requests, labeled by API version")
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   tmap <- liftIO $ STM.newTVarIO Map.empty
@@ -119,6 +125,7 @@ initMetrics _config = do
     , getBlocksWithNbdrByBlockSpan = getBlocksWithNbdrByBlockSpan
     , getBlocksWithHashrateByBlockSpan = getBlocksWithHashrateByBlockSpan
     , getSingleBlockspan = getSingleBlockspan
+    , apiVersionRequests = apiVersionRequests
     , dynamicHistograms = tmap
     }
 


### PR DESCRIPTION
## Summary

Implements items **3 (metrics)** and **4 (disable v1)** of #120 (Migration & Deprecation). Items 1 (deprecation headers) and 2 (frontend feature flag) are already handled / obsolete since the frontend now talks only to v2.

A single WAI middleware wired into the HTTP app (`OpEnergy.Server.runServer`) handles both concerns:

### Disable deprecated v1 endpoints (410 Gone)
Gated behind a new config flag `configDisableDeprecatedV1Api` (env `DISABLE_DEPRECATED_V1_API`), **defaulting to `true`**. No handler code is removed — v1 can be re-enabled per-environment with `DISABLE_DEPRECATED_V1_API=false`.

**Disabled with a v2 successor** (410 body points to v2):
- `/api/v1/blockspans/statistics`
- `/api/v1/oe/block`, `/api/v1/oe/blockbyheight`
- `/api/v1/oe/blocksbyblockspan`, `/api/v1/oe/blockswithnbdrbyblockspan`
- `/api/v1/oe/git-hash`
- `/api/v1/ws` (frontend migrated to `/api/v2/blockspans/ws`)

**Disabled without a v2 successor** (generic deprecation body; unused by frontend):
- `/api/v1/oe/blockswithhashratebyblockspan`, `/api/v1/oe/blockspanlist`

### Track v1 vs v2 traffic
Adds a prometheus counter `api_requests_total` labeled by `version` (`v1`/`v2`), incremented by the middleware.

## Files changed
- `src/OpEnergy/Server.hs` — migration middleware + wiring
- `src/OpEnergy/Server/V1/Config.hs` — `configDisableDeprecatedV1Api` flag (default `true`)
- `src/OpEnergy/Server/V1/Metrics.hs` — `api_requests_total{version}` counter
- `op-energy-backend.cabal` + `derivation.nix` — add `wai`/`http-types` deps

## Testing
Built with `nix-shell shell.nix --run "cabal build"` (`-Wall -Werror`, clean). Ran the backend against Postgres and verified with curl:

- All v1 endpoints (incl. `ws`) → `410 Gone` with correct differentiated messages
- v2 endpoints → `200` (real data, pass-through)
- `api_requests_total{version="v1"}` / `{version="v2"}` increment as expected
- With `DISABLE_DEPRECATED_V1_API=false`, v1 endpoints pass through (`200`)

## Notes
- Cross-repo cleanup items from #121 (PersonUUID guess lookup, statistics rebuild) live in the strikes backend and are out of scope here.